### PR TITLE
Saturation

### DIFF
--- a/src/net/amunak/bukkit/flywithfood/FlyWithFood.java
+++ b/src/net/amunak/bukkit/flywithfood/FlyWithFood.java
@@ -239,26 +239,26 @@ public class FlyWithFood extends JavaPlugin {
                         && !player.hasPermission("fly.nohunger")) {
                     //remoce from saturation first if we can, then do food level
                     if (player.getSaturation() > 0) {
-												int newSaturationLevel = player.getSaturation() - this.plugin.config.getInt("options.drainHunger.rate");
-												if (newSaturationLevel < 0) {
-														newSaturationLevel = 0;
-												}
-												if (newSaturationLevel > 20) {
-														newSaturationLevel = 20;
-												}
-												player.setSaturation(newSaturationLevel);
-                    		log.fine(player.getName() + " now has saturation of " + newSaturationLevel);
+                        int newSaturationLevel = player.getSaturation() - this.plugin.config.getInt("options.drainHunger.rate");
+                        if (newSaturationLevel < 0) {
+                            newSaturationLevel = 0;
+                        }
+                        if (newSaturationLevel > 20) {
+                            newSaturationLevel = 20;
+                        }
+                        player.setSaturation(newSaturationLevel);
+                        log.fine(player.getName() + " now has saturation of " + newSaturationLevel);
                     }
                     else {
-												int newFoodLevel = player.getFoodLevel() - this.plugin.config.getInt("options.drainHunger.rate");
-												if (newFoodLevel < 0) {
-														newFoodLevel = 0;
-												}
-												if (newFoodLevel > 20) {
-														newFoodLevel = 20;
-												}
-                    		player.setFoodLevel(newFoodLevel);
-                    		log.fine(player.getName() + " now has foodLevel of " + newFoodLevel);
+                        int newFoodLevel = player.getFoodLevel() - this.plugin.config.getInt("options.drainHunger.rate");
+                        if (newFoodLevel < 0) {
+                            newFoodLevel = 0;
+                        }
+                        if (newFoodLevel > 20) {
+                            newFoodLevel = 20;
+                        }
+                        player.setFoodLevel(newFoodLevel);
+                        log.fine(player.getName() + " now has foodLevel of " + newFoodLevel);
                     }
                     this.plugin.foodLevelCheck(player, newFoodLevel);
                 }

--- a/src/net/amunak/bukkit/flywithfood/FlyWithFood.java
+++ b/src/net/amunak/bukkit/flywithfood/FlyWithFood.java
@@ -233,19 +233,33 @@ public class FlyWithFood extends JavaPlugin {
         @Override
         public void run() {
             for (Player player : this.plugin.getServer().getOnlinePlayers()) {
-                //Remove hunger if player is in survival, flying and has no bypass
+                //Remove hunger/saturation if player is in survival, flying and has no bypass
                 if (player.getGameMode().equals(GameMode.SURVIVAL)
                         && player.isFlying()
                         && !player.hasPermission("fly.nohunger")) {
-                    int newFoodLevel = player.getFoodLevel() - this.plugin.config.getInt("options.drainHunger.rate");
-                    if (newFoodLevel < 0) {
-                        newFoodLevel = 0;
+                    //remoce from saturation first if we can, then do food level
+                    if (player.getSaturation() > 0) {
+												int newSaturationLevel = player.getSaturation() - this.plugin.config.getInt("options.drainHunger.rate");
+												if (newSaturationLevel < 0) {
+														newSaturationLevel = 0;
+												}
+												if (newSaturationLevel > 20) {
+														newSaturationLevel = 20;
+												}
+												player.setSaturation(newSaturationLevel);
+                    		log.fine(player.getName() + " now has saturation of " + newSaturationLevel);
                     }
-                    if (newFoodLevel > 20) {
-                        newFoodLevel = 20;
+                    else {
+												int newFoodLevel = player.getFoodLevel() - this.plugin.config.getInt("options.drainHunger.rate");
+												if (newFoodLevel < 0) {
+														newFoodLevel = 0;
+												}
+												if (newFoodLevel > 20) {
+														newFoodLevel = 20;
+												}
+                    		player.setFoodLevel(newFoodLevel);
+                    		log.fine(player.getName() + " now has foodLevel of " + newFoodLevel);
                     }
-                    player.setFoodLevel(newFoodLevel);
-                    log.fine(player.getName() + " now has foodLevel of " + newFoodLevel);
                     this.plugin.foodLevelCheck(player, newFoodLevel);
                 }
             }

--- a/src/net/amunak/bukkit/flywithfood/FlyWithFood.java
+++ b/src/net/amunak/bukkit/flywithfood/FlyWithFood.java
@@ -237,9 +237,10 @@ public class FlyWithFood extends JavaPlugin {
                 if (player.getGameMode().equals(GameMode.SURVIVAL)
                         && player.isFlying()
                         && !player.hasPermission("fly.nohunger")) {
-                    //remoce from saturation first if we can, then do food level
+                    int newFoodLevel = player.getFoodLevel();
+                    //remove from saturation first if we can, then do food level
                     if (player.getSaturation() > 0) {
-                        int newSaturationLevel = player.getSaturation() - this.plugin.config.getInt("options.drainHunger.rate");
+                        float newSaturationLevel = player.getSaturation() - this.plugin.config.getInt("options.drainHunger.rate");
                         if (newSaturationLevel < 0) {
                             newSaturationLevel = 0;
                         }
@@ -250,7 +251,7 @@ public class FlyWithFood extends JavaPlugin {
                         log.fine(player.getName() + " now has saturation of " + newSaturationLevel);
                     }
                     else {
-                        int newFoodLevel = player.getFoodLevel() - this.plugin.config.getInt("options.drainHunger.rate");
+                        newFoodLevel = player.getFoodLevel() - this.plugin.config.getInt("options.drainHunger.rate");
                         if (newFoodLevel < 0) {
                             newFoodLevel = 0;
                         }


### PR DESCRIPTION
I made it so it should remove from saturation before removing from foodLevel. I think it's just a really simple thing of basically removing from saturation first if we can, then removing from foodLevel. So I haven't really tested it at all. That, plus this is the first time I've done anything with CraftBukkit plugins, and wasn't sure how to go about setting up an eclipse project, make the jar, testing on my server, blah, blah, all with a plugin that already existed and wasn't created fresh in eclipse.

I didn't even think about making it optional in the config until just now, but seeing as this should now mirror the default hunger mechanics, I wouldn't think anybody would want it as optional.
